### PR TITLE
feat: add edit form

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,6 @@
+import { match, P } from "ts-pattern";
+import * as lunchMoney from "./lunchmoney";
+import { Icon, Color, Image } from "@raycast/api";
+
+export const getFormatedAmount = (transaction: lunchMoney.Transaction): string =>
+    `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}`

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,4 @@
 import * as lunchMoney from "./lunchmoney";
 
 export const getFormatedAmount = (transaction: lunchMoney.Transaction): string =>
-  `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}`;
+  Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base);

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,6 +1,4 @@
-import { match, P } from "ts-pattern";
 import * as lunchMoney from "./lunchmoney";
-import { Icon, Color, Image } from "@raycast/api";
 
 export const getFormatedAmount = (transaction: lunchMoney.Transaction): string =>
-    `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}`
+  `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}`;

--- a/src/lunchmoney.ts
+++ b/src/lunchmoney.ts
@@ -97,6 +97,7 @@ export interface Transaction {
   is_income: boolean;
   display_name?: string;
   display_note: string | null;
+  account_display_name: string;
 
   // recurring
   recurring_id: number | null;

--- a/src/lunchmoney.ts
+++ b/src/lunchmoney.ts
@@ -201,3 +201,24 @@ export const updateTransaction = async (
   });
   return response.json();
 };
+
+export interface Category {
+  id: number;
+  name: string;
+  description: string;
+  is_income: boolean;
+  exclude_from_budget: boolean;
+  exclude_from_totals: boolean;
+  updated_at: string;
+  created_at: string;
+  is_group: boolean;
+  group_id?: number;
+  children?: Category[];
+}
+
+export const getCategories = async (): Promise<Category[]> => {
+  const response = await client.get<{ categories: Category[] }>("v1/categories", {
+    searchParams: { format: "nested" },
+  });
+  return (await response.json()).categories;
+};

--- a/src/lunchmoney.ts
+++ b/src/lunchmoney.ts
@@ -148,6 +148,46 @@ export interface Category {
   children?: Category[];
 }
 
+export interface SummarizedTransaction {
+  id: number;
+  date: string;
+  amount: string;
+  currency: string;
+  payee: string;
+  category_id?: number;
+  recurring_id?: number;
+  to_base: number;
+}
+
+export interface RecurringItem {
+  id: number;
+  start_date?: string;
+  end_date?: string;
+  payee: string;
+  currency: string;
+  created_at: string;
+  updated_at: string;
+  billing_date: string;
+  original_name?: string;
+  description?: string;
+  plaid_account_id?: number;
+  asset_id?: number;
+  source: 'manual' | 'transaction' | 'system' | 'null';
+  notes?: string;
+  amount: string;
+  category_id?: number;
+  category_group_id?: number;
+  is_income: boolean;
+  exclude_from_totals: boolean;
+  granularity: 'day' | 'week' | 'month' | 'year';
+  quantity?: number;
+  occurrences: Record<string, SummarizedTransaction[]>;
+  transactions_within_range?: SummarizedTransaction[];
+  missing_dates_within_range?: string[];
+  date?: string;
+  to_base: number;
+}
+
 export interface DraftTransaction {
   date: string;
   category_id?: number;
@@ -222,4 +262,9 @@ export const getCategories = async (): Promise<Category[]> => {
 export const getTags = async (): Promise<Tag[]> => {
   const response = await client.get<Tag[]>("v1/tags");
   return response.json();
+};
+
+export const getRecurringItems = async (): Promise<RecurringItem[]> => {
+  const response = await client.get<RecurringItem[]>(`v1/recurring_items`)
+  return response.json()
 };

--- a/src/lunchmoney.ts
+++ b/src/lunchmoney.ts
@@ -145,7 +145,9 @@ export interface Category {
   created_at: string;
   is_group: boolean;
   group_id?: number;
+  children?: Category[];
 }
+
 export interface DraftTransaction {
   date: string;
   category_id?: number;
@@ -162,6 +164,8 @@ export interface DraftTransaction {
 export interface Tag {
   id: number;
   name: string;
+  description: string;
+  archived: boolean;
 }
 
 export type TransactionsEndpointArguments = {
@@ -188,10 +192,16 @@ export const getTransactions = async (args?: TransactionsEndpointArguments): Pro
   return (await response.json()).transactions;
 };
 
+export const getTransaction = async (transactionId: number): Promise<Transaction> => {
+  const response = await client.get<Transaction>(`v1/transactions/${transactionId}`)
+  return response.json();
+};
+
 export type UpdateTransactionResponse = {
   updated: boolean;
   split?: number[];
 };
+
 export const updateTransaction = async (
   transactionId: number,
   args: TransactionUpdate,
@@ -202,23 +212,14 @@ export const updateTransaction = async (
   return response.json();
 };
 
-export interface Category {
-  id: number;
-  name: string;
-  description: string;
-  is_income: boolean;
-  exclude_from_budget: boolean;
-  exclude_from_totals: boolean;
-  updated_at: string;
-  created_at: string;
-  is_group: boolean;
-  group_id?: number;
-  children?: Category[];
-}
-
 export const getCategories = async (): Promise<Category[]> => {
   const response = await client.get<{ categories: Category[] }>("v1/categories", {
     searchParams: { format: "nested" },
   });
   return (await response.json()).categories;
+};
+
+export const getTags = async (): Promise<Tag[]> => {
+  const response = await client.get<Tag[]>("v1/tags");
+  return response.json();
 };

--- a/src/lunchmoney.ts
+++ b/src/lunchmoney.ts
@@ -172,14 +172,14 @@ export interface RecurringItem {
   description?: string;
   plaid_account_id?: number;
   asset_id?: number;
-  source: 'manual' | 'transaction' | 'system' | 'null';
+  source: "manual" | "transaction" | "system" | "null";
   notes?: string;
   amount: string;
   category_id?: number;
   category_group_id?: number;
   is_income: boolean;
   exclude_from_totals: boolean;
-  granularity: 'day' | 'week' | 'month' | 'year';
+  granularity: "day" | "week" | "month" | "year";
   quantity?: number;
   occurrences: Record<string, SummarizedTransaction[]>;
   transactions_within_range?: SummarizedTransaction[];
@@ -233,7 +233,7 @@ export const getTransactions = async (args?: TransactionsEndpointArguments): Pro
 };
 
 export const getTransaction = async (transactionId: number): Promise<Transaction> => {
-  const response = await client.get<Transaction>(`v1/transactions/${transactionId}`)
+  const response = await client.get<Transaction>(`v1/transactions/${transactionId}`);
   return response.json();
 };
 
@@ -265,6 +265,6 @@ export const getTags = async (): Promise<Tag[]> => {
 };
 
 export const getRecurringItems = async (): Promise<RecurringItem[]> => {
-  const response = await client.get<RecurringItem[]>(`v1/recurring_items`)
-  return response.json()
+  const response = await client.get<RecurringItem[]>(`v1/recurring_items`);
+  return response.json();
 };

--- a/src/transactions.tsx
+++ b/src/transactions.tsx
@@ -2,6 +2,7 @@ import { ActionPanel, List, Action, Icon, Color, Image, showToast, Toast } from 
 import { useCachedPromise } from "@raycast/utils";
 import { match, P } from "ts-pattern";
 import * as lunchMoney from "./lunchmoney";
+import { EditTransactionForm } from "./transactions_form"
 import { useMemo, useState } from "react";
 import { compareDesc, eachMonthOfInterval, endOfMonth, format, parse, startOfMonth, startOfYear } from "date-fns";
 import { alphabetical, group, sift, sort } from "radash";
@@ -49,6 +50,10 @@ function TransactionListItem({
     onValidate(transaction);
   };
 
+  function mutate(): void {
+    throw new Error("Function not implemented.");
+  }
+
   return (
     <List.Item
       title={`${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}`}
@@ -70,8 +75,18 @@ function TransactionListItem({
       actions={
         <ActionPanel>
           {transaction.status != lunchMoney.TransactionStatus.CLEARED && !transaction.is_pending && (
-            <Action title="Validate" icon={Icon.CheckCircle} onAction={validate} />
+            <Action
+              title="Validate"
+              shortcut={{ modifiers: [], key: "enter" }}
+              icon={Icon.CheckCircle}
+              onAction={validate} />
           )}
+          <Action.Push
+            title="Edit Transaction"
+            shortcut={{ modifiers: [], key: "arrowRight" }}
+            icon={Icon.Pencil}
+            target={<EditTransactionForm transaction={transaction} onUpdate={mutate} />}
+          />
           <Action.OpenInBrowser
             title="View Payee in Lunch Money"
             url={`https://my.lunchmoney.app/transactions/${format(transaction.date, "yyyy/MM")}?match=all&payee_exact=${encodeURIComponent(transaction.payee)}&time=month`}

--- a/src/transactions.tsx
+++ b/src/transactions.tsx
@@ -59,7 +59,7 @@ function TransactionListItem({
       subtitle={getTransactionSubtitle(transaction)}
       icon={getTransactionIcon(transaction)}
       accessories={sift([
-        { text: `${transaction.plaid_account_name ?? transaction.asset_name ?? ""}` },
+        { text: transaction.account_display_name },
         transaction.is_group ? { icon: Icon.Folder, tooltip: "Group" } : undefined,
         ...(transaction.tags?.map((tag) => ({ tag: tag.name })) ?? []),
         transaction.category_name ? { tag: transaction.category_name, icon: Icon.Tag } : undefined,

--- a/src/transactions.tsx
+++ b/src/transactions.tsx
@@ -2,7 +2,7 @@ import { ActionPanel, List, Action, Icon, Color, Image, showToast, Toast } from 
 import { useCachedPromise } from "@raycast/utils";
 import { match, P } from "ts-pattern";
 import * as lunchMoney from "./lunchmoney";
-import { EditTransactionForm } from "./transactions_form"
+import { EditTransactionForm } from "./transactions_form";
 import { useMemo, useState } from "react";
 import { compareDesc, eachMonthOfInterval, endOfMonth, format, parse, startOfMonth, startOfYear } from "date-fns";
 import { alphabetical, group, sift, sort } from "radash";
@@ -40,7 +40,6 @@ export const getTransactionSubtitle = (transaction: lunchMoney.Transaction) =>
     )
     .otherwise(() => transaction.payee);
 
-
 function TransactionListItem({
   transaction,
   onValidate,
@@ -75,11 +74,7 @@ function TransactionListItem({
       actions={
         <ActionPanel>
           {transaction.status != lunchMoney.TransactionStatus.CLEARED && !transaction.is_pending && (
-            <Action
-              title="Validate"
-              icon={Icon.CheckCircle}
-              onAction={validate}
-            />
+            <Action title="Validate" icon={Icon.CheckCircle} onAction={validate} />
           )}
           <Action.Push
             title="Edit Transaction"
@@ -216,23 +211,21 @@ export default function Command() {
     });
 
     try {
-      await mutate(
-        lunchMoney.updateTransaction(transaction.id, update),
-        {
-          optimisticUpdate: (currentData) => {
-            if (!currentData) return currentData;
-            return currentData.map((tx) => {
-              if (tx.id === transaction.id) {
-                tx.payee = update.payee ? update.payee : transaction.payee;
-                tx.status = update.status ? update.status : transaction.status;
-                tx.notes = update.notes ? update.notes : transaction.notes;
-                tx.category_id = update.category_id ? update.category_id : transaction.category_id;
-                tx.date = update.date ? update.date : transaction.date;
-              }
-              return tx;
-            });
-          },
-        });
+      await mutate(lunchMoney.updateTransaction(transaction.id, update), {
+        optimisticUpdate: (currentData) => {
+          if (!currentData) return currentData;
+          return currentData.map((tx) => {
+            if (tx.id === transaction.id) {
+              tx.payee = update.payee ? update.payee : transaction.payee;
+              tx.status = update.status ? update.status : transaction.status;
+              tx.notes = update.notes ? update.notes : transaction.notes;
+              tx.category_id = update.category_id ? update.category_id : transaction.category_id;
+              tx.date = update.date ? update.date : transaction.date;
+            }
+            return tx;
+          });
+        },
+      });
 
       toast.style = Toast.Style.Success;
       toast.title = "Transaction updated";
@@ -243,7 +236,7 @@ export default function Command() {
         toast.message = error.message;
       }
     }
-  }
+  };
 
   return (
     <List isLoading={isLoading} searchBarAccessory={<TransactionsDropdown value={month} onChange={setMonth} />}>

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -2,7 +2,7 @@
 import { Action, ActionPanel, Form, Icon, useNavigation } from "@raycast/api";
 import { useCachedPromise, useForm } from "@raycast/utils";
 import * as lunchMoney from "./lunchmoney";
-import { Key, useMemo, useState } from "react";
+import { useState } from "react";
 import { getFormatedAmount } from "./format";
 import { formatISO } from "date-fns";
 import { all } from "radash";
@@ -139,13 +139,9 @@ export function EditTransactionForm({
     },
   });
 
-  const tagItems = useMemo(() => {
-    const items = tags.map((tag: { id: Key | null | undefined; name: string }) => (
-      <Form.TagPicker.Item key={tag.id} value={String(tag.id)} title={tag.name} />
-    ));
-    const newItems = newTags.map((tagName) => <Form.TagPicker.Item key={tagName} value={tagName} title={tagName} />);
-    return [...items, ...newItems];
-  }, [tags, newTags]);
+  const tagItems = tags
+    .map((tag) => <Form.TagPicker.Item key={tag.id} value={String(tag.id)} title={tag.name} />)
+    .concat(newTags.map((tagName) => <Form.TagPicker.Item key={tagName} value={tagName} title={tagName} />));
 
   const AddTag = () => {
     const { handleSubmit, itemProps } = useForm<{ tag: string }>({

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -1,203 +1,192 @@
 // Add this new component
-import { Action, ActionPanel, Form, Icon, List, Toast, showToast, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Form, Icon, useNavigation } from "@raycast/api";
 import { useCachedPromise, useForm } from "@raycast/utils";
 import * as lunchMoney from "./lunchmoney";
 import { Key, useMemo, useState } from "react";
 import { getFormatedAmount } from "./format";
 
 export function EditTransactionForm({
-    transaction,
-    onEdit,
+  transaction,
+  onEdit,
 }: {
-    transaction: lunchMoney.Transaction;
-    onEdit: (transaction: lunchMoney.Transaction, update: lunchMoney.TransactionUpdate) => void;
+  transaction: lunchMoney.Transaction;
+  onEdit: (transaction: lunchMoney.Transaction, update: lunchMoney.TransactionUpdate) => void;
 }) {
-    const { pop } = useNavigation();
-    const { data: categories, isLoading: isLoadingCategories } = useCachedPromise(lunchMoney.getCategories, []);
-    const { data: recuringItems, isLoading: isLoadingRecuringItems } = useCachedPromise(lunchMoney.getRecurringItems, []);
-    const { data: tags, isLoading: isLoadingTags } = useCachedPromise(lunchMoney.getTags, []);
-    const [newTags, setNewTags] = useState<string[]>([]);
-    const [selectedTags, setSelectedTags] = useState<string[]>(
-        transaction.tags?.map(tag => String(tag.id)) || []
-    );
-    const [date, setDate] = useState<Date | null>(new Date(transaction.date));
-    let formattedDate = new Intl.DateTimeFormat('en-CA', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-    })
+  const { pop } = useNavigation();
+  const { data: categories, isLoading: isLoadingCategories } = useCachedPromise(lunchMoney.getCategories, []);
+  const { data: recuringItems, isLoading: isLoadingRecuringItems } = useCachedPromise(lunchMoney.getRecurringItems, []);
+  const { data: tags, isLoading: isLoadingTags } = useCachedPromise(lunchMoney.getTags, []);
+  const [newTags, setNewTags] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>(transaction.tags?.map((tag) => String(tag.id)) || []);
+  const [date, setDate] = useState<Date | null>(new Date(transaction.date));
+  const formattedDate = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
 
-    const { handleSubmit, itemProps } = useForm<{
-        payee: string;
-        category_id: string;
-        recuring_id: string;
-        reviewed: boolean; // XXX: should handle 3 states (+PENDING) and toggle 2 states (CLEARED/UNCLEARED).
-        amount: string;
-        notes: string;
-        date: Date;
-    }>({
-        onSubmit: async (values) => {
-            const toast = await showToast({
-                style: Toast.Style.Animated,
-                title: "Updating transaction...",
-            });
+  const { handleSubmit, itemProps } = useForm<{
+    payee: string;
+    category_id: string;
+    recuring_id: string;
+    reviewed: boolean; // XXX: should handle 3 states (+PENDING) and toggle 2 states (CLEARED/UNCLEARED).
+    amount: string;
+    notes: string;
+    date: Date;
+  }>({
+    onSubmit: async (values) => {
+      const tagsToUpdate = selectedTags.map((tag: string) => {
+        const id = parseInt(tag, 10);
+        return isNaN(id) ? tag : id;
+      });
+      const update: lunchMoney.TransactionUpdate = {
+        payee: values.payee,
+        category_id: values.category_id ? parseInt(values.category_id) : undefined,
+        tags: tagsToUpdate,
+        status: values.reviewed ? lunchMoney.TransactionStatus.CLEARED : lunchMoney.TransactionStatus.UNCLEARED,
+        notes: values.notes,
+        date: date ? formattedDate.format(date) : undefined,
+      };
 
-            const tagsToUpdate = selectedTags.map((tag: string) => {
-                const id = parseInt(tag, 10);
-                return isNaN(id) ? tag : id;
-            });
-            const update: lunchMoney.TransactionUpdate = {
-                payee: values.payee,
-                category_id: values.category_id ? parseInt(values.category_id) : undefined,
-                tags: tagsToUpdate,
-                status: values.reviewed ? lunchMoney.TransactionStatus.CLEARED : lunchMoney.TransactionStatus.UNCLEARED,
-                notes: values.notes,
-                date: date ? formattedDate.format(date) : undefined
-            }
+      onEdit(transaction, update);
+      pop();
+    },
+    validation: {
+      payee: (value) => {
+        if (!value?.length) return "Payee is required";
+      },
+    },
+    initialValues: {
+      payee: transaction.payee,
+      category_id: transaction.category_id?.toString() ?? "",
+      recuring_id: transaction.recurring_id?.toString() ?? "",
+      amount: transaction.amount,
+      notes: transaction.notes,
+      // We can assume that if the user is editing and updating the
+      // transaction, it is considered reviewed until the user manually
+      // unchecks the box.
+      // XXX: use tx default state.
+      reviewed: true,
+    },
+  });
 
-            onEdit(transaction, update);
-            pop();
+  const renderCategories = (categories?: lunchMoney.Category[]) => {
+    if (!categories) return null;
+
+    return categories.map((category) => {
+      if (category.is_group && category.children) {
+        return (
+          <Form.Dropdown.Section key={category.id} title={category.name}>
+            {category.children.map((child) => (
+              <Form.Dropdown.Item
+                key={child.id}
+                value={String(child.id)}
+                title={child.name}
+                icon={category.id === transaction.category_id ? Icon.Check : undefined}
+              />
+            ))}
+          </Form.Dropdown.Section>
+        );
+      }
+
+      return (
+        <Form.Dropdown.Item
+          key={category.id}
+          value={String(category.id)}
+          title={category.name}
+          icon={category.id === transaction.category_id ? Icon.Check : undefined}
+        />
+      );
+    });
+  };
+
+  const renderRecuring = (recurings?: lunchMoney.RecurringItem[]) => {
+    if (!recurings) return null;
+
+    return recurings.map((recuring) => {
+      return (
+        <Form.Dropdown.Item
+          key={recuring.id}
+          value={String(recuring.id)}
+          title={recuring.payee}
+          icon={recuring.id === transaction.recurring_id ? Icon.Check : undefined}
+        />
+      );
+    });
+  };
+
+  const tagItems = useMemo(() => {
+    if (!tags) return [];
+    const items = tags.map((tag: { id: Key | null | undefined; name: string }) => (
+      <Form.TagPicker.Item key={tag.id} value={String(tag.id)} title={tag.name} />
+    ));
+    const newItems = newTags.map((tagName) => <Form.TagPicker.Item key={tagName} value={tagName} title={tagName} />);
+    return [...items, ...newItems];
+  }, [tags, newTags]);
+
+  const AddTag = () => {
+    const { handleSubmit, itemProps } = useForm<{ tag: string }>({
+      onSubmit(values) {
+        console.log(values);
+        setNewTags([...newTags, values.tag]);
+        setSelectedTags([...selectedTags, values.tag]);
+        pop();
+      },
+      validation: {
+        tag: (value) => {
+          if (tags && tags.find((el) => el.name == value)) {
+            return "This Tag already exist";
+          }
+          if (!value) {
+            return "Name is required";
+          }
         },
-        validation: {
-            payee: (value) => {
-                if (!value?.length) return "Payee is required";
-            },
-        },
-        initialValues: {
-            payee: transaction.payee,
-            category_id: transaction.category_id?.toString() ?? "",
-            recuring_id: transaction.recurring_id?.toString() ?? "",
-            amount: transaction.amount,
-            notes: transaction.notes,
-            // We can assume that if the user is editing and updating the
-            // transaction, it is considered reviewed until the user manually
-            // unchecks the box.
-            // XXX: use tx default state.
-            reviewed: true,
-        },
+      },
     });
 
-    const renderCategories = (categories?: lunchMoney.Category[]) => {
-        if (!categories) return null;
-
-        return categories.map((category) => {
-            if (category.is_group && category.children) {
-                return (
-                    <Form.Dropdown.Section key={category.id} title={category.name}>
-                        {category.children.map((child) => (
-                            <Form.Dropdown.Item
-                                key={child.id}
-                                value={String(child.id)}
-                                title={child.name}
-                                icon={category.id === transaction.category_id ? Icon.Check : undefined}
-                            />
-                        ))}
-                    </Form.Dropdown.Section>
-                );
-            }
-
-            return (
-                <Form.Dropdown.Item
-                    key={category.id}
-                    value={String(category.id)}
-                    title={category.name}
-                    icon={category.id === transaction.category_id ? Icon.Check : undefined}
-                />
-            );
-        });
-    };
-
-    const renderRecuring = (recurings?: lunchMoney.RecurringItem[]) => {
-        if (!recurings) return null;
-
-        return recurings.map((recuring) => {
-            return (
-                <Form.Dropdown.Item
-                    key={recuring.id}
-                    value={String(recuring.id)}
-                    title={recuring.payee}
-                    icon={recuring.id === transaction.recurring_id ? Icon.Check : undefined}
-                />
-            );
-        });
-    };
-
-    const tagItems = useMemo(() => {
-        if (!tags) return [];
-        const items = tags.map((tag: { id: Key | null | undefined; name: string; }) => (
-            <Form.TagPicker.Item key={tag.id} value={String(tag.id)} title={tag.name} />
-        ));
-        const newItems = newTags.map((tagName) => (
-            <Form.TagPicker.Item key={tagName} value={tagName} title={tagName} />
-        ));
-        return [...items, ...newItems];
-    }, [tags, newTags]);
-
-    const AddTag = () => {
-        const { handleSubmit, itemProps } = useForm<{ tag: string }>({
-            onSubmit(values) {
-                console.log(values)
-                setNewTags([...newTags, values.tag])
-                setSelectedTags([...selectedTags, values.tag])
-                pop()
-            },
-            validation: {
-                tag: (value) => {
-                    if (tags && tags.find((el) => el.name == value)) {
-                        return "This Tag already exist"
-                    }
-                    if (!value) {
-                        return "Name is required"
-                    }
-                },
-            },
-        });
-
-        return (
-            <Form
-                actions={
-                    <ActionPanel>
-                        <Action.SubmitForm title="Create" onSubmit={handleSubmit} />
-                    </ActionPanel>
-                }
-            >
-                <Form.TextField title="Name" placeholder="My Tag" {...itemProps.tag} />
-            </Form>
-        );
-    }
-
     return (
-        <Form
-            isLoading={isLoadingCategories || isLoadingTags || isLoadingRecuringItems}
-            actions={
-                <ActionPanel>
-                    <Action.SubmitForm title="Save Changes" onSubmit={handleSubmit} />
-                    <Action.Push title="Add Tag" shortcut={{ modifiers: ["cmd"], key: "t" }} target={<AddTag />} />
-                    <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} />
-                </ActionPanel>
-            }
-        >
-            <Form.Description title={"Transaction"} text={`${getFormatedAmount(transaction)} using '${transaction.plaid_account_name}'`} />
-            <Form.TextField title="Payee" placeholder="Transaction payee" {...itemProps.payee} />
-            <Form.Dropdown title="Category" {...itemProps.category_id}>
-                <Form.Dropdown.Item title="No Category" value="" icon={Icon.XMarkCircle} />
-                {renderCategories(categories)}
-            </Form.Dropdown>
-            <Form.TextArea title="Notes" {...itemProps.notes} />
-            <Form.TagPicker
-                id="tags"
-                title="Tags"
-                value={selectedTags}
-                onChange={setSelectedTags}
-            >
-                {tagItems}
-            </Form.TagPicker>
-            <Form.DatePicker title="Date" type={Form.DatePicker.Type.Date} value={date} onChange={setDate} id="date" />
-            <Form.Dropdown title="Recuring Expenses" {...itemProps.recuring_id}>
-                <Form.Dropdown.Item title="No Recuring Expenses" value="" icon={Icon.XMarkCircle} />
-                {renderRecuring(recuringItems)}
-            </Form.Dropdown>
-            <Form.Checkbox title="Status" label="Reviewed" {...itemProps.reviewed} />
-        </Form>
+      <Form
+        actions={
+          <ActionPanel>
+            <Action.SubmitForm title="Create" onSubmit={handleSubmit} />
+          </ActionPanel>
+        }
+      >
+        <Form.TextField title="Name" placeholder="My Tag" {...itemProps.tag} />
+      </Form>
     );
+  };
+
+  return (
+    <Form
+      isLoading={isLoadingCategories || isLoadingTags || isLoadingRecuringItems}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Save Changes" onSubmit={handleSubmit} />
+          <Action.Push title="Add Tag" shortcut={{ modifiers: ["cmd"], key: "t" }} target={<AddTag />} />
+          <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description
+        title={"Transaction"}
+        text={`${getFormatedAmount(transaction)} using '${transaction.plaid_account_name}'`}
+      />
+      <Form.TextField title="Payee" placeholder="Transaction payee" {...itemProps.payee} />
+      <Form.Dropdown title="Category" {...itemProps.category_id}>
+        <Form.Dropdown.Item title="No Category" value="" icon={Icon.XMarkCircle} />
+        {renderCategories(categories)}
+      </Form.Dropdown>
+      <Form.TextArea title="Notes" {...itemProps.notes} />
+      <Form.TagPicker id="tags" title="Tags" value={selectedTags} onChange={setSelectedTags}>
+        {tagItems}
+      </Form.TagPicker>
+      <Form.DatePicker title="Date" type={Form.DatePicker.Type.Date} value={date} onChange={setDate} id="date" />
+      <Form.Dropdown title="Recuring Expenses" {...itemProps.recuring_id}>
+        <Form.Dropdown.Item title="No Recuring Expenses" value="" icon={Icon.XMarkCircle} />
+        {renderRecuring(recuringItems)}
+      </Form.Dropdown>
+      <Form.Checkbox title="Status" label="Reviewed" {...itemProps.reviewed} />
+    </Form>
+  );
 }

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -1,0 +1,110 @@
+// Add this new component
+import { Action, ActionPanel, Form, Icon, Toast, showToast, useNavigation } from "@raycast/api";
+import { useCachedPromise, useForm } from "@raycast/utils";
+import * as lunchMoney from "./lunchmoney";
+
+export function EditTransactionForm({
+    transaction,
+    onUpdate,
+}: {
+    transaction: lunchMoney.Transaction;
+    onUpdate: () => void;
+}) {
+    const { pop } = useNavigation();
+    const { data: categories, isLoading } = useCachedPromise(lunchMoney.getCategories, []);
+    const { handleSubmit, itemProps } = useForm<{
+        payee: string;
+        category_id: string;
+        reviewed: boolean;
+        amount: string;
+    }>({
+        onSubmit: async (values) => {
+            const toast = await showToast({
+                style: Toast.Style.Animated,
+                title: "Updating transaction...",
+            });
+
+            try {
+                await lunchMoney.updateTransaction(transaction.id, {
+                    payee: values.payee,
+                    category_id: values.category_id ? parseInt(values.category_id) : undefined,
+                });
+
+                toast.style = Toast.Style.Success;
+                toast.title = "Transaction updated";
+
+                // onUpdate(); // XXX: do we have to update cached tx ?
+
+                pop();
+            } catch (error) {
+                toast.style = Toast.Style.Failure;
+                toast.title = "Failed to update transaction";
+                if (error instanceof Error) {
+                    toast.message = error.message;
+                }
+            }
+        },
+        validation: {
+            payee: (value) => {
+                if (!value?.length) return "Payee is required";
+            },
+        },
+        initialValues: {
+            payee: transaction.payee,
+            category_id: transaction.category_id?.toString() ?? "",
+            reviewed: transaction.status == lunchMoney.TransactionStatus.CLEARED,
+            amount: transaction.amount,
+        },
+    });
+
+    const renderCategories = (categories?: lunchMoney.Category[]) => {
+        if (!categories) return null;
+
+        return categories.map((category) => {
+            if (category.is_group && category.children) {
+                return (
+                    <Form.Dropdown.Section key={category.id} title={category.name}>
+                        {category.children.map((child) => (
+                            <Form.Dropdown.Item
+                                key={child.id}
+                                value={String(child.id)}
+                                title={child.name}
+                                icon={category.id === transaction.category_id ? Icon.Check : undefined}
+                            />
+                        ))}
+                    </Form.Dropdown.Section>
+                );
+            }
+
+            return (
+                <Form.Dropdown.Item
+                    key={category.id}
+                    value={String(category.id)}
+                    title={category.name}
+                    icon={category.id === transaction.category_id ? Icon.Check : undefined}
+                />
+            );
+        });
+    };
+
+    return (
+        <Form
+            isLoading={isLoading}
+            actions={
+                <ActionPanel>
+                    <Action.SubmitForm title="Save Changes" onSubmit={handleSubmit} />
+                    <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} />
+                </ActionPanel>
+            }
+        >
+            <Form.Description title={`Transaction`} text={transaction.date} />
+            <Form.TextField title="Payee" placeholder="Transaction payee" {...itemProps.payee} />
+            <Form.TextField title="Amount" placeholder="Transaction amount" {...itemProps.amount} />
+            <Form.Dropdown title="Category" {...itemProps.category_id}>
+                <Form.Dropdown.Item title="No Category" value="" icon={Icon.XMarkCircle} />
+                {renderCategories(categories)}
+            </Form.Dropdown>
+            <Form.Checkbox title="Status" label="Reviewed" {...itemProps.reviewed} />
+        </Form>
+    );
+}

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -117,7 +117,7 @@ export function EditTransactionForm({
         });
     };
 
-    const formatedAmount = `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}}`
+    const formatedAmount = `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}`
 
     return (
         <Form
@@ -125,7 +125,7 @@ export function EditTransactionForm({
             actions={
                 <ActionPanel>
                     <Action.SubmitForm title="Save Changes" onSubmit={handleSubmit} />
-                    <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} f />
+                    <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} />
                 </ActionPanel>
             }
         >

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -93,6 +93,7 @@ export function EditTransactionForm({
   const [newTags, setNewTags] = useState<string[]>([]);
   const [selectedTags, setSelectedTags] = useState<string[]>(transaction.tags?.map((tag) => String(tag.id)) || []);
   const [date, setDate] = useState<Date | null>(new Date(transaction.date));
+  const [isTagsFocused, setTagsFocused] = useState(false);
 
   const { handleSubmit, itemProps } = useForm<{
     payee: string;
@@ -181,8 +182,13 @@ export function EditTransactionForm({
       isLoading={isLoading}
       actions={
         <ActionPanel>
+          {isTagsFocused && (
+            <Action.Push title="Create New Tag" shortcut={{ modifiers: ["cmd"], key: "t" }} target={<AddTag />} />
+          )}
           <Action.SubmitForm title="Save Changes" onSubmit={handleSubmit} />
-          <Action.Push title="Add Tag" shortcut={{ modifiers: ["cmd"], key: "t" }} target={<AddTag />} />
+          {!isTagsFocused && (
+            <Action.Push title="Create New Tag" shortcut={{ modifiers: ["cmd"], key: "t" }} target={<AddTag />} />
+          )}
           <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} />
         </ActionPanel>
       }
@@ -197,7 +203,14 @@ export function EditTransactionForm({
         <TransactionFormCategories transaction={transaction} categories={categories} />
       </Form.Dropdown>
       <Form.TextArea title="Notes" {...itemProps.notes} />
-      <Form.TagPicker id="tags" title="Tags" value={selectedTags} onChange={setSelectedTags}>
+      <Form.TagPicker
+        id="tags"
+        title="Tags"
+        value={selectedTags}
+        onChange={setSelectedTags}
+        onFocus={() => setTagsFocused(true)}
+        onBlur={() => setTagsFocused(false)}
+      >
         {tagItems}
       </Form.TagPicker>
       <Form.DatePicker title="Date" type={Form.DatePicker.Type.Date} value={date} onChange={setDate} id="date" />

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -195,7 +195,7 @@ export function EditTransactionForm({
     >
       <Form.Description
         title={"Transaction"}
-        text={`${getFormatedAmount(transaction)} using '${transaction.plaid_account_name}'`}
+        text={`${getFormatedAmount(transaction)} using '${transaction.account_display_name}'`}
       />
       <Form.TextField title="Payee" placeholder="Transaction payee" {...itemProps.payee} />
       <Form.Dropdown title="Category" {...itemProps.category_id}>

--- a/src/transactions_form.tsx
+++ b/src/transactions_form.tsx
@@ -2,21 +2,30 @@
 import { Action, ActionPanel, Form, Icon, Toast, showToast, useNavigation } from "@raycast/api";
 import { useCachedPromise, useForm } from "@raycast/utils";
 import * as lunchMoney from "./lunchmoney";
+import { Key, useMemo, useState } from "react";
 
 export function EditTransactionForm({
     transaction,
-    onUpdate,
+    onEdit,
 }: {
     transaction: lunchMoney.Transaction;
-    onUpdate: () => void;
+    onEdit: (transaction: lunchMoney.Transaction, update: lunchMoney.TransactionUpdate) => void;
 }) {
     const { pop } = useNavigation();
-    const { data: categories, isLoading } = useCachedPromise(lunchMoney.getCategories, []);
+    const { data: categories, isLoading: isLoadingCategories } = useCachedPromise(lunchMoney.getCategories, []);
+    const { data: tags, isLoading: isLoadingTags } = useCachedPromise(lunchMoney.getTags, []);
+
+    const [searchText, setSearchText] = useState("");
+    const [selectedTags, setSelectedTags] = useState<string[]>(
+        transaction.tags?.map(tag => String(tag.id)) || []
+    );
+
     const { handleSubmit, itemProps } = useForm<{
         payee: string;
         category_id: string;
         reviewed: boolean;
         amount: string;
+        notes: string;
     }>({
         onSubmit: async (values) => {
             const toast = await showToast({
@@ -24,25 +33,22 @@ export function EditTransactionForm({
                 title: "Updating transaction...",
             });
 
-            try {
-                await lunchMoney.updateTransaction(transaction.id, {
-                    payee: values.payee,
-                    category_id: values.category_id ? parseInt(values.category_id) : undefined,
-                });
+            const tagsToUpdate = selectedTags.map((tag: string) => {
+                console.log(tag)
+                const id = parseInt(tag, 10);
+                return isNaN(id) ? tag : id;
+            });
 
-                toast.style = Toast.Style.Success;
-                toast.title = "Transaction updated";
-
-                // onUpdate(); // XXX: do we have to update cached tx ?
-
-                pop();
-            } catch (error) {
-                toast.style = Toast.Style.Failure;
-                toast.title = "Failed to update transaction";
-                if (error instanceof Error) {
-                    toast.message = error.message;
-                }
+            const update: lunchMoney.TransactionUpdate = {
+                payee: values.payee,
+                category_id: values.category_id ? parseInt(values.category_id) : undefined,
+                tags: tagsToUpdate,
+                status: values.reviewed ? lunchMoney.TransactionStatus.CLEARED : lunchMoney.TransactionStatus.UNCLEARED,
+                notes: values.notes,
             }
+
+            onEdit(transaction, update);
+            pop();
         },
         validation: {
             payee: (value) => {
@@ -52,10 +58,34 @@ export function EditTransactionForm({
         initialValues: {
             payee: transaction.payee,
             category_id: transaction.category_id?.toString() ?? "",
-            reviewed: transaction.status == lunchMoney.TransactionStatus.CLEARED,
             amount: transaction.amount,
+            notes: transaction.notes,
+            // We can assume that if the user is editing and updating the
+            // transaction, it is considered reviewed until the user manually
+            // unchecks the box.
+            reviewed: true,
         },
     });
+
+    const tagItems = useMemo(() => {
+        if (!tags) return [];
+        const filteredTags = tags.filter((tag: { name: string; }) =>
+            tag.name.toLowerCase().includes(searchText.toLowerCase())
+        );
+        const items = filteredTags.map((tag: { id: Key | null | undefined; name: string; }) => (
+            <Form.TagPicker.Item key={tag.id} value={String(tag.id)} title={tag.name} />
+        ));
+        if (searchText && !tags.some((tag: { name: any; }) => tag.name === searchText)) {
+            items.push(
+                <Form.TagPicker.Item
+                    key="create"
+                    value={searchText}
+                    title={`Create "${searchText}"`}
+                />
+            );
+        }
+        return items;
+    }, [tags, searchText]);
 
     const renderCategories = (categories?: lunchMoney.Category[]) => {
         if (!categories) return null;
@@ -87,24 +117,42 @@ export function EditTransactionForm({
         });
     };
 
+    const formatedAmount = `${Intl.NumberFormat("en-US", { style: "currency", currency: transaction.currency }).format(transaction.to_base)}}`
+
     return (
         <Form
-            isLoading={isLoading}
+            isLoading={isLoadingCategories || isLoadingTags}
             actions={
                 <ActionPanel>
                     <Action.SubmitForm title="Save Changes" onSubmit={handleSubmit} />
-                    <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} />
+                    <Action title="Back" shortcut={{ modifiers: [], key: "arrowLeft" }} onAction={pop} f />
                 </ActionPanel>
             }
         >
-            <Form.Description title={`Transaction`} text={transaction.date} />
             <Form.TextField title="Payee" placeholder="Transaction payee" {...itemProps.payee} />
-            <Form.TextField title="Amount" placeholder="Transaction amount" {...itemProps.amount} />
             <Form.Dropdown title="Category" {...itemProps.category_id}>
                 <Form.Dropdown.Item title="No Category" value="" icon={Icon.XMarkCircle} />
                 {renderCategories(categories)}
             </Form.Dropdown>
+            <Form.TagPicker
+                id="tags"
+                title="Tags"
+                value={selectedTags}
+                onChange={setSelectedTags}
+            >
+                {tagItems}
+            </Form.TagPicker>
+            <Form.TextArea title="Notes" {...itemProps.notes} />
             <Form.Checkbox title="Status" label="Reviewed" {...itemProps.reviewed} />
+
+            <Form.Separator />
+
+            {transaction.display_name &&
+                <Form.Description title={`Name`} text={transaction.display_name} />}
+            <Form.Description title={`Date`} text={transaction.date} />
+            {transaction.plaid_account_name &&
+                <Form.Description title={`Account`} text={transaction.plaid_account_name} />}
+            <Form.Description title={`Amount`} text={formatedAmount} />
         </Form>
     );
 }


### PR DESCRIPTION
This PR introduces an edit form that appears when the user presses the right arrow to edit a transaction. After making edits, the user can press `cmd+enter` to update the transaction or use the left arrow to return.

Editing support includes:
-  Categories
-  Note
-  Tags 
	- with an additional form to add them using `cmd+t` (I couldn't find a better solution)
-  Edit date
-  Linked Recurring Item
-  Status Update

(outdated)
![Screenshot 2025-01-30 at 12 29 16](https://github.com/user-attachments/assets/97aa737b-bf50-4609-8644-2e31645a3477)

### TODO
-  [x] Fix shortcut; it seems that the right arrow shortcut has overridden the previous `enter` shortcut.
-  [x] Clean up amount to 2 decimal digits (trim right-side 0 digits).
-  [x] Add currency.
-  [x] Ensure transactions are correctly updated after the update on the client side (no need to refetch if the transaction is successful).
-  [x] Fix additional tags support